### PR TITLE
fix: add scheme to blog link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ernail-blog
 
-My personal [blog](blog.nailforge.dev/blog) written completely in Markdown
+My personal [blog](https://blog.nailforge.dev/blog) written completely in Markdown
 
 ## Contributing
 


### PR DESCRIPTION
Without the scheme it's treated as a relative link.